### PR TITLE
Show image notice title field

### DIFF
--- a/webapp/home/admin_forms.py
+++ b/webapp/home/admin_forms.py
@@ -109,7 +109,6 @@ class NoticeAdminForm(forms.ModelForm):
         data = self.cleaned_data
         if data['notice_class'] == 'none':
             data['static_display'] = False
-            data['title'] = ''
             data['display_title'] = False
             data['short_description'] = ''
             data['material_icon'] = ''

--- a/webapp/home/static/home/js/admin-notices.js
+++ b/webapp/home/static/home/js/admin-notices.js
@@ -3,19 +3,15 @@
     if (image_class === 'none') {
       // Image class - hide redundant fields
       $('.field-static_display').hide();
-      $('.field-title').hide();
       $('.field-display_title').hide();
       $('.field-short_description').hide();
       $('.field-material_icon').hide();
-      $('.field-title').removeAttr('required');
     } else {
       // Show fields
       $('.field-static_display').show();
-      $('.field-title').show();
       $('.field-display_title').show();
       $('.field-short_description').show();
       $('.field-material_icon').show();
-      $('.field-title').prop('required', true);
     }
   }
 

--- a/webapp/home/templates/home/index.html
+++ b/webapp/home/templates/home/index.html
@@ -22,11 +22,11 @@
     </a>
   </section>
 
-  <section class="container-fluid my-5" id="tagline">
+  <section class="container-fluid my-3" id="tagline">
 
     {% include 'home/snippets/static-notices.html' %}
 
-    <p>
+    <p class="mt-4">
       Galaxy Australia is an
       <b> open, web-based </b>
       platform for accessible, reproducible

--- a/webapp/home/templates/home/index.html
+++ b/webapp/home/templates/home/index.html
@@ -22,11 +22,11 @@
     </a>
   </section>
 
-  <section class="container-fluid my-3" id="tagline">
+  <section class="container-fluid" id="tagline">
 
     {% include 'home/snippets/static-notices.html' %}
 
-    <p class="mt-4">
+    <p class="my-5">
       Galaxy Australia is an
       <b> open, web-based </b>
       platform for accessible, reproducible


### PR DESCRIPTION
Image notices should have the title field displayed in admin form, so that title can be used to distinguish records in list view