### PR TITLE
Pat capon39 patch 1

### DIFF
--- a/webapp/home/forms.py
+++ b/webapp/home/forms.py
@@ -392,7 +392,7 @@ class FgeneshRequestForm(BaseAccessRequestForm):
 class CellRangerRequestForm(BaseAccessRequestForm):
     """Form to request AlphaFold access."""
 
-    RESOURCE_NAME = 'CellRanger'
+    RESOURCE_NAME = 'Cell Ranger'
     AUTO_ACTION = True
 
     name = forms.CharField()
@@ -403,7 +403,7 @@ class CellRangerRequestForm(BaseAccessRequestForm):
     terms = {
         'button_text': 'View license agreement',
         'src': static('home/documents/cellranger-end-user-license.html'),
-        'agreement_name': 'CellRanger End User Licence Agreement',
+        'agreement_name': 'Cell Ranger End User Licence Agreement',
     }
 
 

--- a/webapp/home/templates/home/requests/access/cellranger.html
+++ b/webapp/home/templates/home/requests/access/cellranger.html
@@ -37,12 +37,12 @@
 
   <p>
     <code>cellranger count</code>
-    takes FASTQ files from cellranger mkfastq and performs alignment, filtering, barcode counting, and UMI counting. It uses the Chromium cellular barcodes to generate feature-barcode matrices, determine clusters, and perform gene expression analysis. The count pipeline can take input from multiple sequencing runs on the same GEM well. cellranger count also processes Feature Barcode data alongside Gene Expression reads.
+    takes FASTQ files from <code>cellranger mkfastq</code> and performs alignment, filtering, barcode counting, and UMI counting. It uses the Chromium cellular barcodes to generate feature-barcode matrices, determine clusters, and perform gene expression analysis. The count pipeline can take input from multiple sequencing runs on the same GEM well. <code>cellranger count</code> also processes Feature Barcode data alongside Gene Expression reads.
   </p>
 
   <p>
     <code>cellranger mkgft</code>
-    a simple utility to filter genes based on their key-value pairs in the GTF attribute column.
+    is a simple utility to filter genes based on their key-value pairs in the GTF attribute column.
   </p>
 
   <p class="mb-10">

--- a/webapp/home/templates/home/requests/access/cellranger.html
+++ b/webapp/home/templates/home/requests/access/cellranger.html
@@ -65,7 +65,7 @@
             href="https://www.10xgenomics.com/end-user-software-license-agreement"
             target="_blank"
           >
-            CellRanger End User Licence Agreement
+            Cell Ranger End User Licence Agreement
           </a>
           must be read and acknowledged prior to access being provisioned.
         </p>
@@ -88,7 +88,7 @@
           required
           {% if form.agree_usage.value %}checked{% endif %}
         />
-        <label for="usageInput" class="form-check-label">I agree to only use CellRanger for academic or non-commercial research purposes</label>
+        <label for="usageInput" class="form-check-label">I agree to only use Cell Ranger for academic or non-commercial research purposes</label>
       </div>
     </div>
 
@@ -96,7 +96,7 @@
       <b>Privacy Collection Notice</b>: by completing this form you agree that your
       responses will be provided to the Australian BioCommons and Galaxy
       Australia and will be used solely for the purposes of determining
-      suitability for access to the Australian CellRanger Service. Your
+      suitability for access to the Australian Cell Ranger Service. Your
       responses will be protected against unauthorised access and use; providing
       your name is required to enable any follow ups. For more information,
       please see the

--- a/webapp/home/templates/home/requests/access/cellranger.html
+++ b/webapp/home/templates/home/requests/access/cellranger.html
@@ -13,7 +13,7 @@
 <main class="container mt-4">
 
   <div class="mb-10">
-    <h2> Galaxy Australia CellRanger Access Request </h2>
+    <h2> Galaxy Australia Cell Ranger Access Request </h2>
     <small>
       <a href="/request/access">
         <span class="material-icons">arrow_back</span>

--- a/webapp/home/templates/home/requests/access/index.html
+++ b/webapp/home/templates/home/requests/access/index.html
@@ -73,7 +73,7 @@
         <div class="card-body">
           <!-- <img src="{% static 'home/img/access-single-cell-dalle.webp' %}" alt="Cartoon illustration of single cell transcriptomics analysis"> -->
           <p class="my-0">
-            Perform single cell RNA-seq analyses withCell Ranger
+            Perform single cell RNA-seq analyses with Cell Ranger
           </p>
         </div>
 

--- a/webapp/home/templates/home/requests/access/index.html
+++ b/webapp/home/templates/home/requests/access/index.html
@@ -41,7 +41,7 @@
     <div class="card-group request-menu-cards">
       <div class="card">
         <div class="card-body">
-          <!-- <img src="{% static 'home/img/access-alphafold-dalle.webp' %}" alt="Cartoon illustration of AlphaFold2 3D protein prediction"> -->
+          <!-- <img src="{% static 'home/img/access-alphafold-dalle.webp' %}" alt="Cartoon illustration of AlphaFold 2 3D protein prediction"> -->
           <p class="my-0">
             Predict protein structures with AlphaFold 2
           </p>

--- a/webapp/home/templates/home/requests/access/index.html
+++ b/webapp/home/templates/home/requests/access/index.html
@@ -23,7 +23,7 @@
     <div class="my-3 mx-auto" style="max-width: 800px;">
       <p>
         Galaxy Australia users from Australian institutions
-        can apply for access to specialized tools. Access to these tools is
+        can apply for access to specialised tools. Access to these tools is
         restricted due to licensing and resource constraints.
         Access will usually be granted automatically if your account email
         address is on our
@@ -43,7 +43,7 @@
         <div class="card-body">
           <!-- <img src="{% static 'home/img/access-alphafold-dalle.webp' %}" alt="Cartoon illustration of AlphaFold2 3D protein prediction"> -->
           <p class="my-0">
-            Use AlphaFold 2 to predict protein structures
+            Predict protein structures with AlphaFold 2
           </p>
         </div>
 
@@ -58,7 +58,7 @@
         <div class="card-body">
           <!-- <img src="{% static 'home/img/access-gene-annotation-dalle.webp' %}" alt="Cartoon illustration of gene annotation analysis"> -->
           <p class="my-0">
-            Use FGENESH++ to annotate a genome
+            Annotate genomes with FGENESH++
           </p>
         </div>
 
@@ -73,7 +73,7 @@
         <div class="card-body">
           <!-- <img src="{% static 'home/img/access-single-cell-dalle.webp' %}" alt="Cartoon illustration of single cell transcriptomics analysis"> -->
           <p class="my-0">
-            Use CellRanger for single cell RNA-seq analysis
+            Perform single cell RNA-seq analyses withCell Ranger
           </p>
         </div>
 

--- a/webapp/home/templates/home/requests/menu.html
+++ b/webapp/home/templates/home/requests/menu.html
@@ -70,7 +70,7 @@
         <h1><span class="material-icons">key</span></h1>
         <div class="card-body">
           <p>
-            Request access to specialised tools AlphaFold2, FGENESH++ and CellRanger
+            Request access to specialised tools AlphaFold2, FGENESH++ and Cell Ranger
           </p>
         </div>
 

--- a/webapp/home/templates/home/requests/menu.html
+++ b/webapp/home/templates/home/requests/menu.html
@@ -70,7 +70,7 @@
         <h1><span class="material-icons">key</span></h1>
         <div class="card-body">
           <p>
-            Request access to specialised tools AlphaFold2, FGENESH++ and Cell Ranger
+            Request access to specialised tools AlphaFold 2, FGENESH++ and Cell Ranger
           </p>
         </div>
 

--- a/webapp/home/templates/home/snippets/header-cards.html
+++ b/webapp/home/templates/home/snippets/header-cards.html
@@ -3,7 +3,7 @@
     <div class="card-body">
       <h1 class="card-title"><span class="material-icons">key</span></h1>
       <p>
-        Request access to specialised tools AlphaFold2, FGENESH++ and CellRanger
+        Request access to specialised tools AlphaFold2, FGENESH++ and Cell Ranger
       </p>
       <a class="ga-btn" href="/request/access">
         Request now

--- a/webapp/home/templates/home/snippets/header-cards.html
+++ b/webapp/home/templates/home/snippets/header-cards.html
@@ -3,7 +3,7 @@
     <div class="card-body">
       <h1 class="card-title"><span class="material-icons">key</span></h1>
       <p>
-        Request access to specialised tools AlphaFold2, FGENESH++ and Cell Ranger
+        Request access to specialised tools AlphaFold 2, FGENESH++ and Cell Ranger
       </p>
       <a class="ga-btn" href="/request/access">
         Request now


### PR DESCRIPTION
Flipped tool access sentences following discussion with Christina to have the action first, before the software name (as not all users will know what the software has to offer, but should be familiar with the action).

Also went through to correct instances of 'CellRanger' to be 'Cell Ranger' as per the [10X Genomics website](https://www.10xgenomics.com/support/software/cell-ranger/latest).