### PR TITLE
Add APPEND_TEXT to support emails

### DIFF
--- a/webapp/home/forms.py
+++ b/webapp/home/forms.py
@@ -17,6 +17,8 @@ from . import validators
 
 logger = logging.getLogger('django')
 
+MAIL_APPEND_TEXT = f"Sent from {settings.HOSTNAME}"
+
 
 def dispatch_form_mail(
         to_address=None,
@@ -32,6 +34,7 @@ def dispatch_form_mail(
     recipient = to_address or settings.EMAIL_TO_ADDRESS
     reply_to_value = [reply_to] if reply_to else None
     logger.info(f"Sending mail to {recipient}")
+    text += f"\n\n\n{MAIL_APPEND_TEXT}"
     email = EmailMultiAlternatives(
         subject,
         text,
@@ -40,6 +43,10 @@ def dispatch_form_mail(
         reply_to=reply_to_value,
     )
     if html:
+        html = html.replace(
+            '</body>',
+            f'<small style="color: gray;">{MAIL_APPEND_TEXT}</small>\n</body>'
+        )
         email.attach_alternative(html, "text/html")
     retry_send_mail(email)
 


### PR DESCRIPTION
Emails sent to FreshDesk from web forms will now have text appended to the bottom "sent from <HOSTNAME>".